### PR TITLE
Use multi-stage for CI package deploy, keep releases for nuget.org

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,28 +1,109 @@
-steps:
+trigger:
+  batch: false
+  branches:
+    include:
+    - master
+    - features/*
+    - releases/*
+    - dev/*
+  paths:
+    exclude:
+    - docs
+pr:
+  - master
+  - features/*
+  - releases/*
 
-- checkout: self
-  clean: true
+variables:
+- group: Sleet
+- name: Configuration
+  value: Release
 
-- task: VSBuild@1
-  displayName: Build
-  inputs:
-    solution: AutoCodeFix.sln
-    configuration: Release
-    msbuildArgs: '/restore /bl:"$(Build.ArtifactStagingDirectory)\build.binlog" /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)'
+stages:
 
-- task: VSTest@2
-  displayName: Test
-  inputs:
-    testAssemblyVer2: src\AutoCodeFix.Tests\bin\*\AutoCodeFix.Tests.dll
-    runInParallel: true
-    codeCoverageEnabled: true
-    diagnosticsEnabled: false
-  timeoutInMinutes: 10
+- stage: Build
+  jobs:
+  - job: Build
+    pool:
+      vmImage: 'windows-2019'
+    steps:
+    - checkout: self
+      clean: true
 
-- task: PublishBuildArtifacts@1
-  displayName: Publish Artifact
-  inputs:
-    PathtoPublish: $(Build.ArtifactStagingDirectory)
-    ArtifactName: out
-    ArtifactType: Container
-  condition: always()
+    - task: MSBuild@1
+      displayName: Restore
+      inputs:
+        solution: AutoCodeFix.sln
+        configuration: $(Configuration)
+        msbuildArguments: -t:restore
+
+    - task: MSBuild@1
+      displayName: Build
+      inputs:
+        solution: AutoCodeFix.sln
+        configuration: $(Configuration)
+        msbuildArguments: -p:GeneratePackageOnBuild=true -p:PackageOutputPath=$(Build.ArtifactStagingDirectory) -bl:"$(Build.ArtifactStagingDirectory)/build.binlog" 
+
+    - task: VSTest@2
+      displayName: Test
+      timeoutInMinutes: 10
+      inputs:
+        testAssemblyVer2: src/AutoCodeFix.Tests/bin/*/AutoCodeFix.Tests.dll
+        runInParallel: true
+        codeCoverageEnabled: true
+        publishRunAttachments: true
+        diagnosticsEnabled: false
+        rerunFailedTests: true
+
+    - task: PublishBuildArtifacts@1
+      displayName: Upload
+      condition: succeeded()
+      inputs:
+        PathtoPublish: $(Build.ArtifactStagingDirectory)
+        ArtifactName: package
+        ArtifactType: Container
+
+- stage: Deploy
+  variables:
+  - name: SleetVersion
+    value: 2.3.33
+  jobs:
+  - deployment: Deploy
+    pool:
+      vmImage: 'windows-2019'
+    environment: sleet
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - pwsh: |
+             $anyinstalled = (dotnet tool list -g | select-string sleet) -ne $null
+             Write-Host "##vso[task.setvariable variable=Sleet.AnyInstalled;]$anyinstalled"
+   
+             $sameinstalled = (dotnet tool list -g | select-string sleet | select-string $(SleetVersion)) -ne $null
+             Write-Host "##vso[task.setvariable variable=Sleet.SameInstalled;]$sameinstalled"
+            displayName: 'Check Sleet installed version'
+
+          - task: DotNetCoreCLI@2
+            displayName: 'Uninstall Sleet if necessary'
+            continueOnError: true
+            condition: and(eq(variables['Sleet.AnyInstalled'], 'True'), eq(variables['Sleet.SameInstalled'], 'False'))
+            inputs:
+              command: custom
+              custom: tool
+              arguments: 'uninstall -g Sleet'
+
+          - task: DotNetCoreCLI@2
+            displayName: 'Install Sleet if necessary'
+            condition: eq(variables['Sleet.SameInstalled'], 'False')
+            inputs:
+              command: custom
+              custom: tool
+              arguments: 'install --global Sleet --version $(SleetVersion)'
+
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifactName: package
+
+          - script: 'sleet push --config none $(Pipeline.Workspace)/package -f --verbose -p "SLEET_FEED_CONNECTIONSTRING=$(SLEET_FEED_CONNECTIONSTRING)"'
+            displayName: 'Push package via Sleet'


### PR DESCRIPTION
Otherwise, the build is pinned by the automated "release" to the CI
nuget feed, which is not something we necessarily want.